### PR TITLE
Fix GitHub Actions and remove macos-12 on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-14 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-13, macos-14, macos-15, macos-latest ]
         name: [ '-head', '+graalvm-head' ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -92,7 +92,8 @@ jobs:
       id: platform
       run: |
         platform=${{ matrix.os }}
-        platform=${platform/macos-14/macos-13-arm64}
+        platform=${platform/macos-14/macos-14-arm64}
+        platform=${platform/macos-15/macos-15-arm64}
         echo "platform=$platform" >> $GITHUB_OUTPUT
 
     # Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-12, macos-14 ]
+        os: [ ubuntu-20.04, ubuntu-22.04, ubuntu-24.04, macos-14 ]
         name: [ '-head', '+graalvm-head' ]
     runs-on: ${{ matrix.os }}
     steps:
@@ -92,7 +92,6 @@ jobs:
       id: platform
       run: |
         platform=${{ matrix.os }}
-        platform=${platform/macos-12/macos-latest}
         platform=${platform/macos-14/macos-13-arm64}
         echo "platform=$platform" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
`macos-12` was deprecated and removed on Dec 3 (see https://github.com/actions/runner-images/issues/10721).

Changes
- removed `macos-12` GitHub runner image
- added `macos-15` GitHub runner image
- added `macos-latest` GitHub runner image that targets macos-14
- use `macos-13` GitHub runner image (instead of `macos-14`) for macOS 13-specific release
- renamed release name suffix for macOS 13 - from macos-13-arm64 to macos-13

Checked the changes in a fork repository - all the jobs passed successfully (https://github.com/andrykonchin/truffleruby-dev-builder/actions/runs/12198035317/job/34028921909)